### PR TITLE
Add OpenShift files

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,0 +1,10 @@
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.11 AS builder
+WORKDIR /go/src/github.com/kubernetes-csi/external-resizer
+COPY . .
+RUN go build ./cmd/csi-resizer
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+COPY --from=builder /go/src/github.com/kubernetes-csi/external-resizer/csi-resizer /usr/bin/
+RUN useradd csi-resizer
+USER csi-resizer
+ENTRYPOINT ["/usr/bin/csi-resizer"]

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,0 +1,10 @@
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+WORKDIR /go/src/github.com/kubernetes-csi/external-resizer
+COPY . .
+RUN go build ./cmd/csi-resizer
+
+FROM registry.svc.ci.openshift.org/ocp/4.0:base
+COPY --from=builder /go/src/github.com/kubernetes-csi/external-resizer/csi-resizer /usr/bin/
+RUN useradd csi-resizer
+USER csi-resizer
+ENTRYPOINT ["/usr/bin/csi-resizer"]

--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,7 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
+  - openshift-storage-maintainers
   - saad-ali
   - gnufied
   - mlmhl

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,0 +1,7 @@
+aliases:
+  openshift-storage-maintainers:
+    - jsafrane
+    - tsmetana
+    - gnufied
+    - childsb
+    - bertinatto


### PR DESCRIPTION
* Add Dockerfiles
* Add OWNERS

@openshift/storage 

Technically, openshift/master is 2 commits ahead of released upstream v0.1.0 that we'd like to have in 4.2, but these two commits look completely harmless: https://github.com/kubernetes-csi/external-resizer/compare/v0.1.0...jsafrane:rebase-v0.1.0?expand=1

Therefore I will not downgrade openshift/master to v0.1.0 and we will ship slightly different version in 4.2.