### PR TITLE
OCPBUGS-14812: Chore: Update OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,4 +2,4 @@
 
 approvers:
 - openshift-storage-maintainers
-component: "Storage"
+component: "Storage / Kubernetes External Components"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,3 +5,5 @@ aliases:
     - gnufied
     - bertinatto
     - dobsonj
+    - RomanBednar
+    - mpatlasov


### PR DESCRIPTION
Changing the component as per the other drivers and adding Maxim in storage maintainers.